### PR TITLE
Add session documentation and document retrieval support

### DIFF
--- a/src/components/therapist/DocumentationCompliance.tsx
+++ b/src/components/therapist/DocumentationCompliance.tsx
@@ -1,11 +1,97 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { supabase } from '../../lib/supabase'
+
+interface DocumentUpload {
+  id: string
+  file_url: string
+}
 
 export const DocumentationCompliance: React.FC = () => {
+  const [sessionId, setSessionId] = useState('')
+  const [note, setNote] = useState('')
+  const [documents, setDocuments] = useState<DocumentUpload[]>([])
+  const [loadingDocs, setLoadingDocs] = useState(false)
+
+  const saveNote = async () => {
+    if (!sessionId || !note) return
+    const { error } = await supabase.rpc('create_session_note', {
+      session_id: sessionId,
+      content: note
+    })
+    if (error) {
+      console.error('Error saving note:', error)
+    } else {
+      setNote('')
+    }
+  }
+
+  const loadDocuments = async () => {
+    if (!sessionId) return
+    setLoadingDocs(true)
+    const { data, error } = await supabase.rpc('get_session_documents', {
+      session_id: sessionId
+    })
+    if (error) {
+      console.error('Error loading documents:', error)
+      setDocuments([])
+    } else {
+      setDocuments(data || [])
+    }
+    setLoadingDocs(false)
+  }
+
+  useEffect(() => {
+    if (sessionId) {
+      loadDocuments()
+    }
+  }, [sessionId])
+
   return (
     <div className="space-y-6">
       <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">Documentation & Compliance</h3>
-        <p className="text-gray-600">Documentation and compliance features coming soon...</p>
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Session Notes</h3>
+        <input
+          type="text"
+          placeholder="Session ID"
+          value={sessionId}
+          onChange={e => setSessionId(e.target.value)}
+          className="mb-2 w-full border rounded p-2"
+        />
+        <textarea
+          className="w-full border rounded p-2 mb-2 h-32"
+          placeholder="Write your session notes..."
+          value={note}
+          onChange={e => setNote(e.target.value)}
+        />
+        <button
+          onClick={saveNote}
+          className="px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+          disabled={!sessionId || !note}
+        >
+          Save Note
+        </button>
+      </div>
+      <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Uploaded Documents</h3>
+        {loadingDocs ? (
+          <p className="text-gray-600">Loading...</p>
+        ) : (
+          <ul className="space-y-2">
+            {documents.map(doc => (
+              <li key={doc.id}>
+                <a
+                  href={doc.file_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:underline"
+                >
+                  {doc.file_url}
+                </a>
+              </li>
+            ))}
+            {documents.length === 0 && <p className="text-gray-600">No documents found.</p>}
+          </ul>
+        )}
       </div>
     </div>
   )

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -231,6 +231,52 @@ export type Database = {
           source_id?: string | null
           recorded_at?: string
         }
+      },
+      session_notes: {
+        Row: {
+          id: string
+          appointment_id: string | null
+          therapist_id: string | null
+          progress_notes: string | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          appointment_id?: string | null
+          therapist_id?: string | null
+          progress_notes?: string | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          appointment_id?: string | null
+          therapist_id?: string | null
+          progress_notes?: string | null
+          created_at?: string
+        }
+      },
+      document_uploads: {
+        Row: {
+          id: string
+          session_id: string | null
+          therapist_id: string | null
+          file_url: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          session_id?: string | null
+          therapist_id?: string | null
+          file_url: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          session_id?: string | null
+          therapist_id?: string | null
+          file_url?: string
+          created_at?: string
+        }
       }
     }
   }

--- a/supabase/migrations/20250814235900_session_documents.sql
+++ b/supabase/migrations/20250814235900_session_documents.sql
@@ -1,0 +1,77 @@
+-- Create session_notes and document_uploads tables (document_uploads new, session_notes ensured)
+-- Add storage bucket and policies for document uploads
+-- Add RPC functions for creating notes and retrieving documents with audit logging
+
+-- Ensure session_notes table exists (if not already)
+CREATE TABLE IF NOT EXISTS session_notes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  appointment_id uuid,
+  therapist_id uuid REFERENCES profiles(id) ON DELETE SET NULL,
+  progress_notes text,
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE session_notes ENABLE ROW LEVEL SECURITY;
+
+-- Document uploads table
+CREATE TABLE IF NOT EXISTS document_uploads (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id uuid,
+  therapist_id uuid REFERENCES profiles(id) ON DELETE SET NULL,
+  file_url text NOT NULL,
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE document_uploads ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "document_uploads_manage_own"
+  ON document_uploads
+  FOR ALL
+  USING (auth.uid() = therapist_id)
+  WITH CHECK (auth.uid() = therapist_id);
+
+-- Storage bucket for documents
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('document-uploads', 'document-uploads', false)
+ON CONFLICT (id) DO NOTHING;
+
+CREATE POLICY "document_uploads_storage_policy"
+  ON storage.objects
+  FOR ALL
+  USING (bucket_id = 'document-uploads' AND auth.uid() = owner)
+  WITH CHECK (bucket_id = 'document-uploads' AND auth.uid() = owner);
+
+-- RPC to create a session note with audit logging
+CREATE OR REPLACE FUNCTION create_session_note(session_id uuid, content text)
+RETURNS session_notes AS $$
+DECLARE
+  new_note session_notes;
+BEGIN
+  INSERT INTO session_notes (appointment_id, therapist_id, progress_notes)
+  VALUES (session_id, auth.uid(), content)
+  RETURNING * INTO new_note;
+
+  INSERT INTO audit_logs (user_id, action, resource_type, resource_id, details)
+  VALUES (auth.uid(), 'create_session_note', 'session_notes', new_note.id, jsonb_build_object('session_id', session_id));
+
+  RETURN new_note;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION create_session_note(uuid, text) TO authenticated;
+
+-- RPC to get documents for a session with audit logging
+CREATE OR REPLACE FUNCTION get_session_documents(session_id uuid)
+RETURNS SETOF document_uploads AS $$
+BEGIN
+  INSERT INTO audit_logs (user_id, action, resource_type, resource_id, details)
+  VALUES (auth.uid(), 'get_session_documents', 'document_uploads', session_id, jsonb_build_object('session_id', session_id));
+
+  RETURN QUERY
+  SELECT * FROM document_uploads
+  WHERE document_uploads.session_id = get_session_documents.session_id
+    AND document_uploads.therapist_id = auth.uid();
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION get_session_documents(uuid) TO authenticated;


### PR DESCRIPTION
## Summary
- add migration for session notes, document uploads, storage policies, and RPC audit logging
- type Supabase tables for session_notes and document_uploads
- implement DocumentationCompliance component with note editor and document list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 147 problems (138 errors, 9 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689a9e24d9ec832b9467911c6d46800c