### PR TITLE
refactor: centralize auth state in context provider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import { Login } from './pages/Login'
 import { Register } from './pages/Register'
 import { ProtectedRoute } from './components/ProtectedRoute'
-import { useAuth } from './hooks/useAuth'
+import { useAuth } from './context/AuthContext'
 
 // Lazy load dashboard components with preload
 const TherapistDashboard = React.lazy(() => 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useAuth } from '../hooks/useAuth'
+import { useAuth } from '../context/AuthContext'
 import { LogOut, Brain } from 'lucide-react'
 
 interface LayoutProps {

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Navigate } from 'react-router-dom'
-import { useAuth } from '../hooks/useAuth'
+import { useAuth } from '../context/AuthContext'
 
 interface ProtectedRouteProps {
   children: React.ReactNode

--- a/src/components/therapist/AssessmentTools.tsx
+++ b/src/components/therapist/AssessmentTools.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { supabase } from '../../lib/supabase'
-import { useAuth } from '../../hooks/useAuth'
+import { useAuth } from '../../context/AuthContext'
 import { 
   ClipboardList, 
   Plus, 

--- a/src/components/therapist/CaseFiles.tsx
+++ b/src/components/therapist/CaseFiles.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { supabase } from '../../lib/supabase'
-import { useAuth } from '../../hooks/useAuth'
+import { useAuth } from '../../context/AuthContext'
 import { 
   FileText, 
   User, 

--- a/src/components/therapist/CaseFormulation.tsx
+++ b/src/components/therapist/CaseFormulation.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { supabase } from '../../lib/supabase'
-import { useAuth } from '../../hooks/useAuth'
+import { useAuth } from '../../context/AuthContext'
 import { 
   Stethoscope, 
   Brain, 

--- a/src/components/therapist/CaseManagement.tsx
+++ b/src/components/therapist/CaseManagement.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { supabase } from '../../lib/supabase'
-import { useAuth } from '../../hooks/useAuth'
+import { useAuth } from '../../context/AuthContext'
 import { CaseFormulation } from './CaseFormulation'
 import { InBetweenSessions } from './InBetweenSessions'
 import { FileText, User, Calendar, TrendingUp, ClipboardList, Plus, Search, Filter, Eye, BarChart3, Clock, CheckCircle, AlertTriangle, Brain, Target, Activity, BookOpen, Award, MessageSquare, Send, PlayCircle, PlusCircle, Stethoscope, Baseline as Timeline, Archive } from 'lucide-react'

--- a/src/components/therapist/ClientManagement.tsx
+++ b/src/components/therapist/ClientManagement.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { supabase } from '../../lib/supabase'
-import { useAuth } from '../../hooks/useAuth'
+import { useAuth } from '../../context/AuthContext'
 import { 
   Users, 
   Plus, 

--- a/src/components/therapist/InBetweenSessions.tsx
+++ b/src/components/therapist/InBetweenSessions.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { supabase } from '../../lib/supabase'
-import { useAuth } from '../../hooks/useAuth'
+import { useAuth } from '../../context/AuthContext'
 import { Baseline as Timeline, Plus, Calendar, TrendingUp, Clock, CheckCircle, AlertTriangle, BarChart3, MessageSquare, Target, Activity, Send, Eye, Filter } from 'lucide-react'
 
 interface InBetweenSessionsProps {

--- a/src/components/therapist/IntakeForm.tsx
+++ b/src/components/therapist/IntakeForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { supabase } from '../../lib/supabase'
-import { useAuth } from '../../hooks/useAuth'
+import { useAuth } from '../../context/AuthContext'
 import { 
   UserPlus, 
   Phone, 

--- a/src/components/therapist/TherapistOnboarding.tsx
+++ b/src/components/therapist/TherapistOnboarding.tsx
@@ -20,7 +20,7 @@ import {
   X
 } from 'lucide-react'
 import { supabase } from '../../lib/supabase'
-import { useAuth } from '../../hooks/useAuth'
+import { useAuth } from '../../context/AuthContext'
 
 interface OnboardingData {
   // Step 1: Basic Info

--- a/src/components/therapist/WorksheetManagement.tsx
+++ b/src/components/therapist/WorksheetManagement.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useAuth } from '../../hooks/useAuth'
+import { useAuth } from '../../context/AuthContext'
 import { supabase } from '../../lib/supabase'
 import { createWorksheet, listWorksheets, assignWorksheet } from '../../lib/worksheets'
 

--- a/src/hooks/useClientData.ts
+++ b/src/hooks/useClientData.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { supabase } from '../lib/supabase'
-import { useAuth } from './useAuth'
+import { useAuth } from '../context/AuthContext'
 
 interface Assignment {
   id: string

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import App from './App.tsx';
-import './index.css';
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App.tsx'
+import './index.css'
+import { AuthProvider } from './context/AuthContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
-  </StrictMode>
-);
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+  </StrictMode>,
+)

--- a/src/pages/ClientDashboard.tsx
+++ b/src/pages/ClientDashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react'
 import { Navigate } from 'react-router-dom'
-import { useAuth } from '../hooks/useAuth'
+import { useAuth } from '../context/AuthContext'
 import { Layout } from '../components/Layout'
 import { PsychometricForm } from '../components/PsychometricForm'
 import { ProgressChart } from '../components/ProgressChart'

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Navigate, Link } from 'react-router-dom'
-import { useAuth } from '../hooks/useAuth'
+import { useAuth } from '../context/AuthContext'
 import { Brain, Eye, EyeOff } from 'lucide-react'
 
 export const Login: React.FC = () => {

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import { useAuth } from '../hooks/useAuth'
+import { useAuth } from '../context/AuthContext'
 import { Brain, Eye, EyeOff } from 'lucide-react'
 
 export const Register: React.FC = () => {

--- a/src/pages/TherapistDashboard.tsx
+++ b/src/pages/TherapistDashboard.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { Layout } from '../components/Layout'
 import { TherapistOnboarding } from '../components/therapist/TherapistOnboarding'
 import { supabase } from '../lib/supabase'
-import { useAuth } from '../hooks/useAuth'
+import { useAuth } from '../context/AuthContext'
 import {
   Users,
   ClipboardList,


### PR DESCRIPTION
## Summary
- move authentication logic into a new `AuthProvider` context and expose `useAuth`
- wrap application with `AuthProvider`
- update components and hooks to consume auth context

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 158 errors, 13 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b681147f8832bbbef3effda64dac8