### PR TITLE
chore: remove profiles debug policy

### DIFF
--- a/supabase/migrations/20250815235900_remove_profiles_debug_policy.sql
+++ b/supabase/migrations/20250815235900_remove_profiles_debug_policy.sql
@@ -1,0 +1,33 @@
+/*
+  # Remove debug profile policy
+
+  1. Drop wide-open `profiles_debug_access` policy
+  2. Provide restricted diagnostic function for controlled profile access
+     - Uses SECURITY DEFINER to bypass RLS
+     - Execution limited to `service_role`
+*/
+
+-- Drop the temporary debug policy
+DROP POLICY IF EXISTS profiles_debug_access ON profiles;
+
+-- Create a restricted diagnostic function for profile access
+CREATE OR REPLACE FUNCTION public.debug_get_profile(p_user_id uuid)
+RETURNS profiles
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Ensure only service role tokens can execute
+  IF coalesce(auth.jwt() ->> 'role', '') <> 'service_role' THEN
+    RAISE EXCEPTION 'insufficient privileges';
+  END IF;
+
+  RETURN QUERY
+  SELECT * FROM public.profiles WHERE id = p_user_id;
+END;
+$$;
+
+-- Limit execution to service role only
+REVOKE ALL ON FUNCTION public.debug_get_profile(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.debug_get_profile(uuid) TO service_role;


### PR DESCRIPTION
## Summary
- remove temporary `profiles_debug_access` policy
- add restricted `debug_get_profile` function for controlled diagnostics

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689b702d3d38832ba2d52a5b38c13445