### PR TITLE
feat: track profile updates

### DIFF
--- a/supabase/migrations/20250806152830_sweet_shape.sql
+++ b/supabase/migrations/20250806152830_sweet_shape.sql
@@ -131,14 +131,13 @@ AS $$
 BEGIN
   -- This will be called when a new user is created in auth.users
   -- We'll create a basic profile that can be updated later
-  INSERT INTO profiles (id, role, first_name, last_name, email, created_at)
+  INSERT INTO profiles (id, role, first_name, last_name, email)
   VALUES (
     NEW.id,
     'client', -- Default role, can be changed later
     COALESCE(NEW.raw_user_meta_data->>'first_name', 'User'),
     COALESCE(NEW.raw_user_meta_data->>'last_name', 'Name'),
-    NEW.email,
-    now()
+    NEW.email
   )
   ON CONFLICT (id) DO NOTHING;
   
@@ -167,8 +166,8 @@ BEGIN
   
   IF auth_user_id IS NOT NULL THEN
     -- Update the user's role
-    UPDATE profiles 
-    SET role = new_role, updated_at = now()
+    UPDATE profiles
+    SET role = new_role
     WHERE id = auth_user_id;
     
     GET DIAGNOSTICS updated_rows = ROW_COUNT;

--- a/supabase/migrations/20250815000000_profiles_updated_at.sql
+++ b/supabase/migrations/20250815000000_profiles_updated_at.sql
@@ -1,0 +1,32 @@
+/*
+  # Add updated_at to profiles
+
+  1. Add updated_at column to profiles with default now()
+  2. Ensure updates to profiles automatically refresh updated_at
+*/
+
+ALTER TABLE profiles
+ADD COLUMN IF NOT EXISTS updated_at timestamptz DEFAULT now();
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_proc
+    WHERE proname = 'update_timestamp_column'
+  ) THEN
+    CREATE FUNCTION update_timestamp_column()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    AS $$
+    BEGIN
+      NEW.updated_at = now();
+      RETURN NEW;
+    END;
+    $$;
+  END IF;
+END $$;
+
+DROP TRIGGER IF EXISTS update_profiles_timestamp ON profiles;
+CREATE TRIGGER update_profiles_timestamp
+BEFORE UPDATE ON profiles
+FOR EACH ROW EXECUTE FUNCTION update_timestamp_column();


### PR DESCRIPTION
## Summary
- add `updated_at` field and trigger to `profiles`
- rely on automatic timestamps for new profiles
- depend on timestamp trigger in `update_user_role`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 168 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689b6feb5b9c832b9ada3cb3a0eefd7c