### PR TITLE
Add RLS policies for session notes

### DIFF
--- a/supabase/migrations/20250815000000_session_notes_policies.sql
+++ b/supabase/migrations/20250815000000_session_notes_policies.sql
@@ -1,0 +1,31 @@
+-- Ensure therapists can manage their own session notes and clients can read their notes
+ALTER TABLE session_notes ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "session_notes_therapist_manage" ON session_notes;
+CREATE POLICY "session_notes_therapist_manage" ON session_notes
+  FOR ALL TO authenticated
+  USING (
+    auth.uid() = session_notes.therapist_id
+    AND EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id = auth.uid() AND p.role = 'therapist'
+    )
+  )
+  WITH CHECK (
+    auth.uid() = session_notes.therapist_id
+    AND EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id = auth.uid() AND p.role = 'therapist'
+    )
+  );
+
+DROP POLICY IF EXISTS "session_notes_client_read" ON session_notes;
+CREATE POLICY "session_notes_client_read" ON session_notes
+  FOR SELECT TO authenticated
+  USING (
+    auth.uid() = session_notes.client_id
+    AND EXISTS (
+      SELECT 1 FROM profiles p
+      WHERE p.id = auth.uid() AND p.role = 'client'
+    )
+  );


### PR DESCRIPTION
## Summary
- enforce therapist ownership on session note CRUD with WITH CHECK
- allow clients to read their own session notes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 168 problems, 156 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b6ff6ac24832bb0bec57d4359fbd7