### PR TITLE
Reset profile policies and add documentation

### DIFF
--- a/docs/PROFILE_POLICIES.md
+++ b/docs/PROFILE_POLICIES.md
@@ -1,0 +1,12 @@
+# Profile Policies
+
+This document defines the expected row level security policies for the `profiles` table. New migrations should reference this list to avoid duplicating or redefining policies.
+
+## Enabled policies
+
+1. **profiles_insert_own** – Allows an authenticated user to insert their own profile (`auth.uid() = id`).
+2. **profiles_select_own** – Allows an authenticated user to read their own profile (`auth.uid() = id`).
+3. **profiles_update_own** – Allows an authenticated user to update their own profile (`auth.uid() = id`).
+4. **profiles_therapists_read_clients** – Allows a therapist to read the profile of a client they are linked to through `therapist_client_relations`.
+
+These policies comprise the minimal, non-recursive set used by the application. Future migrations should drop any existing profile policies and recreate only these definitions when changes are necessary.

--- a/supabase/migrations/20250815000000_reset_profile_policies.sql
+++ b/supabase/migrations/20250815000000_reset_profile_policies.sql
@@ -1,0 +1,42 @@
+-- Final migration to reset profile table policies
+
+-- Ensure row level security is enabled
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+-- Drop any existing profile policies
+DROP POLICY IF EXISTS profiles_select_own ON profiles;
+DROP POLICY IF EXISTS profiles_insert_own ON profiles;
+DROP POLICY IF EXISTS profiles_update_own ON profiles;
+DROP POLICY IF EXISTS profiles_therapists_read_clients ON profiles;
+DROP POLICY IF EXISTS profiles_therapist_view_clients ON profiles;
+DROP POLICY IF EXISTS profiles_client_read_own ON profiles;
+DROP POLICY IF EXISTS profiles_therapist_full_access ON profiles;
+DROP POLICY IF EXISTS profiles_debug_access ON profiles;
+
+-- Minimal, non-recursive profile policies
+-- Users can create their own profile
+CREATE POLICY profiles_insert_own ON profiles
+  FOR INSERT TO authenticated
+  WITH CHECK (auth.uid() = id);
+
+-- Users can read their own profile
+CREATE POLICY profiles_select_own ON profiles
+  FOR SELECT TO authenticated
+  USING (auth.uid() = id);
+
+-- Users can update their own profile
+CREATE POLICY profiles_update_own ON profiles
+  FOR UPDATE TO authenticated
+  USING (auth.uid() = id)
+  WITH CHECK (auth.uid() = id);
+
+-- Therapists can read profiles of their clients
+CREATE POLICY profiles_therapists_read_clients ON profiles
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM therapist_client_relations tcr
+      WHERE tcr.therapist_id = auth.uid()
+        AND tcr.client_id = profiles.id
+    )
+  );


### PR DESCRIPTION
## Summary
- Drop all existing profile policies and recreate a minimal, non-recursive set
- Document the expected profile policies to prevent duplication in future migrations

## Testing
- `npm run lint` *(fails: many existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689b702139b4832b8ab13ba7a3b0ae2c