### PR TITLE
Handle nullable auth init ref

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -38,7 +38,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [profile, setProfile] = useState<Profile | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const initializeAuthRef = useRef<() => Promise<void>>()
+  const initializeAuthRef = useRef<(() => Promise<void>) | null>(null)
 
   useEffect(() => {
     let mounted = true
@@ -164,7 +164,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const retryAuth = () => {
     setError(null)
     setLoading(true)
-    initializeAuthRef.current && initializeAuthRef.current()
+    initializeAuthRef.current?.()
   }
 
   const signIn = async (email: string, password: string) => {


### PR DESCRIPTION
## Summary
- Allow `initializeAuthRef` to be null and update retry logic accordingly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: found 157 errors, 12 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689b9e3910ec832b98c3c193189e466e