### PR TITLE
feat: retry authentication without page reload

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,7 +76,7 @@ class ErrorBoundary extends React.Component<
 }
 
 function App() {
-  const { user, profile, loading, error } = useAuth()
+  const { user, profile, loading, error, retryAuth } = useAuth()
 
   // Preload dashboards when user is detected
   React.useEffect(() => {
@@ -90,6 +90,10 @@ function App() {
   }
 
   if (error) {
+    const errorTitle = error.includes('timed out')
+      ? 'Connection Timeout'
+      : 'Authentication Error'
+
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50">
         <div className="text-center max-w-md mx-auto p-6">
@@ -98,10 +102,10 @@ function App() {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
             </svg>
           </div>
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">Connection Error</h2>
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">{errorTitle}</h2>
           <p className="text-gray-600 mb-4">{error}</p>
           <button
-            onClick={() => window.location.reload()}
+            onClick={retryAuth}
             className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
           >
             Retry

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -239,14 +239,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     <AuthContext.Provider
       value={{ user, profile, loading, error, signIn, signUp, signOut, retryAuth }}
     >
-      {error?.includes('timed out') && (
-        <div className="p-4 text-center text-red-600">
-          <p>{error}</p>
-          <button onClick={retryAuth} className="mt-2 underline">
-            Retry
-          </button>
-        </div>
-      )}
       {children}
     </AuthContext.Provider>
   )


### PR DESCRIPTION
## Summary
- remove internal timeout error screen from `AuthContext`
- use `retryAuth` in `App` to retry authentication without refreshing
- show a consistent auth error screen that distinguishes timeouts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 169 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689ba008b6f0832b87c34ddc7706409c