### PR TITLE
Add supervision and support components

### DIFF
--- a/src/components/therapist/ContactSupport.tsx
+++ b/src/components/therapist/ContactSupport.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+
+export const ContactSupport: React.FC = () => {
+  return (
+    <div className="max-w-xl mx-auto bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+      <h2 className="text-2xl font-bold text-gray-900 mb-4">Contact Support</h2>
+      <p className="text-gray-600 mb-4">
+        Need help? Send us a message and our support team will get back to you.
+      </p>
+      <form className="space-y-4">
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            placeholder="you@example.com"
+            className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+        <div>
+          <label htmlFor="message" className="block text-sm font-medium text-gray-700 mb-1">
+            Message
+          </label>
+          <textarea
+            id="message"
+            rows={4}
+            placeholder="How can we help?"
+            className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+        <button
+          type="submit"
+          className="inline-flex items-center px-4 py-2 border border-transparent rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-700"
+        >
+          Send Message
+        </button>
+      </form>
+      <div className="mt-6 text-sm text-gray-600">
+        <p>
+          Or reach us directly at{' '}
+          <a href="mailto:support@cogniflow.com" className="text-blue-600 hover:underline">
+            support@cogniflow.com
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  )
+}
+

--- a/src/components/therapist/Supervision.tsx
+++ b/src/components/therapist/Supervision.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+export const Supervision: React.FC = () => {
+  return (
+    <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
+      <h2 className="text-2xl font-bold text-gray-900 mb-4">Supervision</h2>
+      <p className="text-gray-600">
+        Tools and resources to support clinical supervision will be available here in a future update.
+      </p>
+    </div>
+  )
+}
+

--- a/src/pages/TherapistDashboard.tsx
+++ b/src/pages/TherapistDashboard.tsx
@@ -34,6 +34,8 @@ const CommunicationTools = React.lazy(() => import('../components/therapist/Comm
 const DocumentationCompliance = React.lazy(() => import('../components/therapist/DocumentationCompliance').then(m => ({ default: m.DocumentationCompliance })))
 const ResourceLibrary = React.lazy(() => import('../components/therapist/ResourceLibrary').then(m => ({ default: m.ResourceLibrary })))
 const PracticeManagement = React.lazy(() => import('../components/therapist/PracticeManagement').then(m => ({ default: m.PracticeManagement })))
+const Supervision = React.lazy(() => import('../components/therapist/Supervision').then(m => ({ default: m.Supervision })))
+const ContactSupport = React.lazy(() => import('../components/therapist/ContactSupport').then(m => ({ default: m.ContactSupport })))
 
 interface DashboardStats {
   totalClients: number
@@ -426,6 +428,18 @@ export const TherapistDashboard: React.FC = () => {
         return (
           <React.Suspense fallback={<div className="flex justify-center py-8"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div></div>}>
             <CommunicationTools />
+          </React.Suspense>
+        )
+      case 'supervision':
+        return (
+          <React.Suspense fallback={<div className="flex justify-center py-8"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div></div>}>
+            <Supervision />
+          </React.Suspense>
+        )
+      case 'support':
+        return (
+          <React.Suspense fallback={<div className="flex justify-center py-8"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div></div>}>
+            <ContactSupport />
           </React.Suspense>
         )
       case 'archive':


### PR DESCRIPTION
## Summary
- Add placeholder Supervision and ContactSupport components
- Lazy-load new components in TherapistDashboard
- Render supervision and support tabs in dashboard content switch

## Testing
- ⚠️ `npm test` (Missing script: "test")
- ❌ `npm run lint` (157 errors, 12 warnings)
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b9f86b9ac832ba2a9021c20aca076