### PR TITLE
feat: improve Supabase auth resiliency

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
+export const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
 if (!supabaseUrl || !supabaseAnonKey) {


### PR DESCRIPTION
## Summary
- export `supabaseUrl` for reuse
- check Supabase connectivity before fetching session and surface clear error

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 166 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bad745b6c832b872659f19712587e