### PR TITLE
fix: harden supabase security config

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,5 @@
+[auth]
+otp_expiry = 600
+
+[auth.password]
+hibp_enabled = true

--- a/supabase/migrations/20250818235900_set_search_path_additional_functions.sql
+++ b/supabase/migrations/20250818235900_set_search_path_additional_functions.sql
@@ -1,0 +1,10 @@
+-- Set search_path to public for additional security definer functions
+ALTER FUNCTION public.insert_progress_metric() SET search_path = public;
+ALTER FUNCTION public.get_user_progress_summary() SET search_path = public;
+ALTER FUNCTION public.get_patient_insights_summary() SET search_path = public;
+ALTER FUNCTION public.get_progress_metrics() SET search_path = public;
+ALTER FUNCTION public.get_therapist_insights() SET search_path = public;
+ALTER FUNCTION public.insert_therapist_insight() SET search_path = public;
+ALTER FUNCTION public.run_security_diagnostics() SET search_path = public;
+ALTER FUNCTION public.auto_assign_user_role() SET search_path = public;
+ALTER FUNCTION public.diagnose_security_invoker() SET search_path = public;


### PR DESCRIPTION
## Summary
- lock down Supabase security with tighter search paths
- add Supabase auth settings for shorter OTP expiry and leaked password checks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_689bcfaceed8832bb1946f89df781894