### PR TITLE
Ensure Supabase credentials and authenticated connectivity

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useRef, useState } from 'react'
 import type { User } from '@supabase/supabase-js'
-import { supabase, supabaseUrl } from '../lib/supabase'
+import { supabase, supabaseUrl, supabaseAnonKey } from '../lib/supabase'
 
 interface Profile {
   id: string
@@ -57,7 +57,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
     const checkSupabaseConnection = async () =>
       withTimeout(
-        fetch(`${supabaseUrl}/rest/v1/`),
+        fetch(`${supabaseUrl}/rest/v1/`, {
+          headers: {
+            apikey: supabaseAnonKey,
+            Authorization: `Bearer ${supabaseAnonKey}`
+          }
+        }),
         30000,
         'Supabase unreachable'
       )

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,9 +1,12 @@
 import { createClient } from '@supabase/supabase-js'
 
 export const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
+export const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
 if (!supabaseUrl || !supabaseAnonKey) {
+  console.error(
+    'Supabase credentials are missing. Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in your environment configuration.'
+  )
   throw new Error('Missing Supabase environment variables')
 }
 


### PR DESCRIPTION
## Summary
- export Supabase anon key and add helpful error message when credentials are missing
- include required apikey and Authorization headers in Supabase connectivity check

## Testing
- `npm run lint` *(fails: 166 problems (154 errors, 12 warnings))*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689bd733bb54832ba28584fed8251b2e