### PR TITLE
chore: set app usage stats view to security invoker

### DIFF
--- a/supabase/migrations/20250819235900_app_usage_stats_security_invoker.sql
+++ b/supabase/migrations/20250819235900_app_usage_stats_security_invoker.sql
@@ -1,0 +1,2 @@
+-- Ensure app_usage_stats view runs with invoker privileges
+ALTER VIEW public.app_usage_stats SET (security_invoker = on);


### PR DESCRIPTION
## Summary
- ensure app_usage_stats view runs with invoker privileges to avoid security definer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 166 problems (154 errors, 12 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689bdb3826b0832b924658b8bd9e3806