### PR TITLE
Replace therapist insights view with table

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -248,6 +248,38 @@ export type Database = {
           updated_at?: string | null
         }
       }
+      therapist_insights_metrics: {
+        Row: {
+          id: string
+          therapist_id: string | null
+          patient_id: string | null
+          metric_type: string
+          metric_value: number | null
+          metric_context: any | null
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: string
+          therapist_id?: string | null
+          patient_id?: string | null
+          metric_type: string
+          metric_value?: number | null
+          metric_context?: any | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: string
+          therapist_id?: string | null
+          patient_id?: string | null
+          metric_type?: string
+          metric_value?: number | null
+          metric_context?: any | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+      }
     }
     Views: {
       progress_metrics: {
@@ -269,13 +301,6 @@ export type Database = {
           average_duration_seconds: number | null
           completed_sessions: number | null
           completion_rate: number | null
-        }
-      }
-      therapist_insights_metrics: {
-        Row: {
-          therapist_id: string | null
-          overdue_assessments: number | null
-          idle_clients: number | null
         }
       }
     }

--- a/supabase/migrations/20250812120000_wise_hill.sql
+++ b/supabase/migrations/20250812120000_wise_hill.sql
@@ -1,60 +1,11 @@
 /*
-  # Therapist insights view and function
+  # Deprecated therapist insights view
 
-  1. Changes
-    - Create view therapist_insights_metrics summarizing metrics for therapists
-    - Create function therapist_insights(id uuid) returning jsonb array of insight objects
-
-  2. Notes
-    - Overdue assessments: form assignments past due date
-    - Idle clients: no appointments in the last 30 days
+  This migration previously created the `therapist_insights_metrics` view and
+  accompanying `therapist_insights` function. The view has been replaced by a
+  real table in a later migration.
 */
 
-CREATE OR REPLACE VIEW therapist_insights_metrics AS
-SELECT
-  t.id AS therapist_id,
-  (
-    SELECT count(*) FROM form_assignments fa
-    WHERE fa.therapist_id = t.id
-      AND fa.status = 'assigned'
-      AND fa.due_date < CURRENT_DATE
-  ) AS overdue_assessments,
-  (
-    SELECT count(*) FROM therapist_client_relations tcr
-    WHERE tcr.therapist_id = t.id
-      AND NOT EXISTS (
-        SELECT 1
-        FROM appointments a
-        WHERE a.therapist_id = t.id
-          AND a.client_id = tcr.client_id
-          AND a.appointment_date >= (CURRENT_DATE - INTERVAL '30 days')
-      )
-  ) AS idle_clients
-FROM profiles t
-WHERE t.role = 'therapist';
-
-CREATE OR REPLACE FUNCTION therapist_insights(id uuid)
-RETURNS jsonb AS $$
-DECLARE
-  metrics RECORD;
-BEGIN
-  SELECT * INTO metrics FROM therapist_insights_metrics WHERE therapist_id = therapist_insights.id;
-
-  RETURN jsonb_build_array(
-    jsonb_build_object(
-      'title', 'Overdue Assessments',
-      'count', COALESCE(metrics.overdue_assessments, 0),
-      'message', COALESCE(metrics.overdue_assessments, 0) || ' assessment(s) overdue',
-      'icon', 'ClipboardList',
-      'severity', CASE WHEN metrics.overdue_assessments > 0 THEN 'warning' ELSE 'success' END
-    ),
-    jsonb_build_object(
-      'title', 'Idle Clients',
-      'count', COALESCE(metrics.idle_clients, 0),
-      'message', COALESCE(metrics.idle_clients, 0) || ' client(s) without recent sessions',
-      'icon', 'Clock',
-      'severity', CASE WHEN metrics.idle_clients > 0 THEN 'warning' ELSE 'success' END
-    )
-  );
-END;
-$$ LANGUAGE plpgsql SECURITY INVOKER;
+-- Remove legacy view and function if they still exist
+DROP VIEW IF EXISTS therapist_insights_metrics CASCADE;
+DROP FUNCTION IF EXISTS therapist_insights(id uuid);

--- a/supabase/migrations/20250819235900_therapist_insights_table.sql
+++ b/supabase/migrations/20250819235900_therapist_insights_table.sql
@@ -1,0 +1,110 @@
+/*
+  # therapist_insights_metrics table
+
+  1. New Table
+    - therapist_insights_metrics stores metrics about therapist insights
+  2. RLS
+    - Enabled
+    - Therapists can manage their own metrics
+*/
+
+CREATE TABLE therapist_insights_metrics (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  therapist_id uuid REFERENCES profiles(id) ON DELETE CASCADE,
+  patient_id uuid REFERENCES profiles(id) ON DELETE CASCADE,
+  metric_type text NOT NULL,
+  metric_value numeric,
+  metric_context jsonb DEFAULT '{}'::jsonb,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE therapist_insights_metrics ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX therapist_insights_metrics_therapist_id_idx ON therapist_insights_metrics (therapist_id);
+CREATE INDEX therapist_insights_metrics_patient_id_idx ON therapist_insights_metrics (patient_id);
+CREATE INDEX therapist_insights_metrics_metric_type_idx ON therapist_insights_metrics (metric_type);
+
+-- RLS policies
+CREATE POLICY "therapist_insights_metrics_select_own" ON therapist_insights_metrics
+  FOR SELECT USING (auth.uid() = therapist_id);
+
+CREATE POLICY "therapist_insights_metrics_insert_own" ON therapist_insights_metrics
+  FOR INSERT WITH CHECK (auth.uid() = therapist_id);
+
+CREATE POLICY "therapist_insights_metrics_update_own" ON therapist_insights_metrics
+  FOR UPDATE USING (auth.uid() = therapist_id) WITH CHECK (auth.uid() = therapist_id);
+
+CREATE POLICY "therapist_insights_metrics_delete_own" ON therapist_insights_metrics
+  FOR DELETE USING (auth.uid() = therapist_id);
+
+-- Functions
+DROP FUNCTION IF EXISTS public.insert_therapist_insight(uuid, uuid, text, numeric, jsonb);
+CREATE OR REPLACE FUNCTION public.insert_therapist_insight(
+  p_therapist_id uuid,
+  p_patient_id uuid,
+  p_metric_type text,
+  p_metric_value numeric,
+  p_metric_context jsonb DEFAULT '{}'::jsonb
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  new_id uuid;
+BEGIN
+  INSERT INTO therapist_insights_metrics (
+    therapist_id, patient_id, metric_type, metric_value, metric_context
+  ) VALUES (
+    p_therapist_id, p_patient_id, p_metric_type, p_metric_value, p_metric_context
+  ) RETURNING id INTO new_id;
+
+  RETURN new_id;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS public.get_patient_insights_summary(uuid);
+CREATE OR REPLACE FUNCTION public.get_patient_insights_summary(patient_id uuid)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  result json;
+BEGIN
+  SELECT json_build_object(
+    'total_metrics', COUNT(*),
+    'latest_metric_date', MAX(created_at),
+    'avg_metric_value', AVG(metric_value)
+  ) INTO result
+  FROM therapist_insights_metrics
+  WHERE patient_id = get_patient_insights_summary.patient_id;
+
+  RETURN result;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS public.get_therapist_insights(uuid);
+CREATE OR REPLACE FUNCTION public.get_therapist_insights(therapist_id uuid)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  result json;
+BEGIN
+  SELECT json_build_object(
+    'total_metrics', COUNT(*),
+    'latest_metric_date', MAX(created_at),
+    'avg_metric_value', AVG(metric_value)
+  ) INTO result
+  FROM therapist_insights_metrics
+  WHERE therapist_id = get_therapist_insights.therapist_id;
+
+  RETURN result;
+END;
+$$;


### PR DESCRIPTION
## Summary
- drop legacy `therapist_insights_metrics` view in existing migrations
- add `therapist_insights_metrics` table with RLS policies and helper functions
- update Supabase types to treat `therapist_insights_metrics` as a table

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 169 problems including type and lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689bdb345a94832b9d669fb89c373860