### PR TITLE
feat: add react-query caching and debounce

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.53.0",
+        "@tanstack/react-query": "^5.85.0",
         "express": "^4.19.2",
         "lucide-react": "^0.536.0",
         "react": "^18.3.1",
@@ -1304,6 +1305,32 @@
         "@supabase/postgrest-js": "1.19.4",
         "@supabase/realtime-js": "2.11.15",
         "@supabase/storage-js": "^2.10.4"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.83.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.1.tgz",
+      "integrity": "sha512-OG69LQgT7jSp+5pPuCfzltq/+7l2xoweggjme9vlbCPa/d7D7zaqv5vN/S82SzSYZ4EDLTxNO1PWrv49RAS64Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.85.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.85.0.tgz",
+      "integrity": "sha512-t1HMfToVMGfwEJRya6GG7gbK0luZJd+9IySFNePL1BforU1F3LqQ3tBC2Rpvr88bOrlU6PXyMLgJD0Yzn4ztUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.83.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.53.0",
     "lucide-react": "^0.536.0",
+    "@tanstack/react-query": "^5.85.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.7.1",

--- a/src/components/therapist/CaseManagement.tsx
+++ b/src/components/therapist/CaseManagement.tsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../context/AuthContext'
-import { CaseFormulation } from './CaseFormulation'
-import { InBetweenSessions } from './InBetweenSessions'
-import { FileText, User, Calendar, TrendingUp, ClipboardList, Plus, Search, Filter, Eye, BarChart3, Clock, CheckCircle, AlertTriangle, Brain, Target, Activity, BookOpen, Award, MessageSquare, Send, PlayCircle, PlusCircle, Stethoscope, Baseline as Timeline, Archive } from 'lucide-react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+const CaseFormulation = React.lazy(() => import('./CaseFormulation').then(m => ({ default: m.CaseFormulation })))
+import { FileText, User, Calendar, TrendingUp, ClipboardList, Plus, Search, Filter, Eye, BarChart3, AlertTriangle, Target, BookOpen, MessageSquare, Send, PlayCircle, Stethoscope, Baseline as Timeline } from 'lucide-react'
 
 interface Client {
   id: string
@@ -63,26 +63,17 @@ interface Assignment {
 }
 
 export const CaseManagement: React.FC = () => {
-  const [caseFiles, setCaseFiles] = useState<CaseFile[]>([])
+  const { profile } = useAuth()
+  const queryClient = useQueryClient()
   const [selectedCase, setSelectedCase] = useState<CaseFile | null>(null)
   const [activeTab, setActiveTab] = useState<'overview' | 'goals' | 'assignments' | 'progress' | 'notes'>('overview')
   const [searchTerm, setSearchTerm] = useState('')
   const [riskFilter, setRiskFilter] = useState('all')
-  const [loading, setLoading] = useState(true)
-  const [showNewAssignment, setShowNewAssignment] = useState(false)
-  const { profile } = useAuth()
-
-  useEffect(() => {
-    if (profile) {
-      fetchCaseFiles()
-    }
-  }, [profile])
 
   const fetchCaseFiles = async () => {
-    if (!profile) return
+    if (!profile) return []
 
     try {
-      // Simplified client fetching to avoid infinite loops
       const { data: relations, error } = await supabase
         .from('therapist_client_relations')
         .select(`
@@ -99,12 +90,10 @@ export const CaseManagement: React.FC = () => {
 
       if (error) {
         console.error('Error fetching relations:', error)
-        setCaseFiles([])
-        return
+        return []
       }
 
-      // Simplified case files - just basic client info for now
-      const cases = (relations || []).map((relation: any) => {
+      const cases = (relations || []).map((relation: { profiles: Client }) => {
         const client = relation.profiles
         return {
           client,
@@ -122,14 +111,18 @@ export const CaseManagement: React.FC = () => {
         }
       })
 
-      setCaseFiles(cases)
+      return cases
     } catch (error) {
       console.error('Error fetching case files:', error)
-      setCaseFiles([])
-    } finally {
-      setLoading(false)
+      return []
     }
   }
+
+  const { data: caseFiles = [], isLoading, error } = useQuery({
+    queryKey: ['case-files', profile?.id],
+    queryFn: fetchCaseFiles,
+    enabled: !!profile?.id
+  })
 
   const handleCreatePlan = async () => {
     if (!selectedCase || !profile) return
@@ -149,7 +142,7 @@ export const CaseManagement: React.FC = () => {
       console.error('Error creating plan:', error)
       alert('Error creating treatment plan. Please try again.')
     } else {
-      fetchCaseFiles()
+      await queryClient.invalidateQueries({ queryKey: ['case-files', profile!.id] })
     }
   }
 
@@ -171,7 +164,7 @@ export const CaseManagement: React.FC = () => {
       console.error('Error adding goal:', error)
       alert('Error adding goal. Please try again.')
     } else {
-      fetchCaseFiles()
+      await queryClient.invalidateQueries({ queryKey: ['case-files', profile!.id] })
     }
   }
 
@@ -188,7 +181,7 @@ export const CaseManagement: React.FC = () => {
       console.error('Error updating goal:', error)
       alert('Error updating goal. Please try again.')
     } else {
-      fetchCaseFiles()
+      await queryClient.invalidateQueries({ queryKey: ['case-files', profile!.id] })
     }
   }
 
@@ -212,7 +205,7 @@ export const CaseManagement: React.FC = () => {
       .eq('id', goalId)
     
     if (!error) {
-      fetchCaseFiles()
+      await queryClient.invalidateQueries({ queryKey: ['case-files', profile!.id] })
     }
   }
 
@@ -255,10 +248,21 @@ export const CaseManagement: React.FC = () => {
     })
   }
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+        <div className="flex items-center space-x-2">
+          <AlertTriangle className="w-5 h-5 text-red-600" />
+          <span className="text-red-800">{error instanceof Error ? error.message : 'Failed to load cases'}</span>
+        </div>
       </div>
     )
   }
@@ -422,10 +426,12 @@ export const CaseManagement: React.FC = () => {
         )}
 
         {activeTab === 'formulation' && (
-          <CaseFormulation 
-            caseFile={selectedCase}
-            onUpdate={fetchCaseFiles}
-          />
+          <React.Suspense fallback={<div>Loading...</div>}>
+            <CaseFormulation
+              caseFile={selectedCase}
+              onUpdate={() => queryClient.invalidateQueries({ queryKey: ['case-files', profile!.id] })}
+            />
+          </React.Suspense>
         )}
 
         {activeTab === 'goals' && (

--- a/src/components/therapist/ClientManagement.tsx
+++ b/src/components/therapist/ClientManagement.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../context/AuthContext'
 import {
@@ -31,9 +32,10 @@ interface ClientProfile {
 }
 
 export const ClientManagement: React.FC = () => {
-  const [clients, setClients] = useState<Client[]>([])
-  const [clientProfiles, setClientProfiles] = useState<Record<string, ClientProfile>>({})
+  const { profile } = useAuth()
+  const queryClient = useQueryClient()
   const [searchTerm, setSearchTerm] = useState('')
+  const [debouncedSearch, setDebouncedSearch] = useState('')
   const [riskFilter, setRiskFilter] = useState<string>('all')
   const [intakeFilter, setIntakeFilter] = useState<string>('all')
   const [stageFilter, setStageFilter] = useState<string>('all')
@@ -41,111 +43,97 @@ export const ClientManagement: React.FC = () => {
   const [selectedClient, setSelectedClient] = useState<Client | null>(null)
   const [showAddClient, setShowAddClient] = useState(false)
   const [showClientDetails, setShowClientDetails] = useState(false)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const { profile } = useAuth()
-  const [page, setPage] = useState(0)
-  const [hasMore, setHasMore] = useState(true)
-  const [loadingMore, setLoadingMore] = useState(false)
   const PAGE_SIZE = 12
-  const fetchClients = async ({ page = 0, search = '', append = false }: { page?: number; search?: string; append?: boolean } = {}) => {
-    if (!profile?.id) return
-
-    if (append) {
-      setLoadingMore(true)
-    } else {
-      setLoading(true)
-      setClients([])
-      setClientProfiles({})
-      setHasMore(true)
-    }
-    setError(null)
-
-    try {
-      let query = supabase
-        .from('therapist_client_relations')
-        .select(`
-          client_id,
-          profiles!therapist_client_relations_client_id_fkey (
-            id,
-            first_name,
-            last_name,
-            email,
-            created_at,
-            whatsapp_number,
-            patient_code
-          )
-        `, { count: 'exact' })
-        .eq('therapist_id', profile.id)
-        .range(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE - 1)
-
-      if (search) {
-        query = query.or(
-          `profiles.first_name.ilike.%${search}%,profiles.last_name.ilike.%${search}%,profiles.email.ilike.%${search}%`
-        )
-      }
-
-      const { data: relations, error: relationsError, count } = await query
-
-      if (relationsError) {
-        console.error('Error fetching client relations:', relationsError)
-        setError('Failed to load clients')
-        if (!append) setClients([])
-        return
-      }
-
-      const clientList = (relations || [])
-        .map((relation: { profiles: Client }) => relation.profiles)
-        .filter(Boolean)
-
-      setClients(prev => (append ? [...prev, ...clientList] : clientList))
-
-      if (clientList.length > 0) {
-        const clientIds = clientList.map(c => c.id)
-        const { data: profiles, error: profilesError } = await supabase
-          .from('client_profiles')
-          .select('client_id, risk_level, presenting_concerns, notes, intake_status, treatment_stage')
-          .in('client_id', clientIds)
-          .eq('therapist_id', profile.id)
-
-        if (!profilesError && profiles) {
-          const profilesMap = profiles.reduce((acc, p) => {
-            acc[p.client_id] = {
-              risk_level: p.risk_level,
-              presenting_concerns: p.presenting_concerns,
-              notes: p.notes,
-              intake_status: p.intake_status,
-              treatment_stage: p.treatment_stage
-            }
-            return acc
-          }, {} as Record<string, ClientProfile>)
-          setClientProfiles(prev => (append ? { ...prev, ...profilesMap } : profilesMap))
-        }
-      }
-
-      setPage(page)
-      if (typeof count === 'number') {
-        setHasMore((page + 1) * PAGE_SIZE < count)
-      } else {
-        setHasMore(clientList.length === PAGE_SIZE)
-      }
-
-    } catch (error) {
-      console.error('Error fetching clients:', error)
-      setError('Failed to load clients')
-      if (!append) setClients([])
-    } finally {
-      setLoading(false)
-      setLoadingMore(false)
-    }
-  }
 
   useEffect(() => {
-    if (profile?.id) {
-      fetchClients({ page: 0, search: searchTerm })
+    const handler = setTimeout(() => setDebouncedSearch(searchTerm), 300)
+    return () => clearTimeout(handler)
+  }, [searchTerm])
+
+  const fetchClients = async ({ pageParam = 0 }: { pageParam?: number }) => {
+    if (!profile?.id) {
+      return { clients: [], profilesMap: {}, hasMore: false, page: pageParam }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [profile?.id, searchTerm])
+
+    let query = supabase
+      .from('therapist_client_relations')
+      .select(`
+        client_id,
+        profiles!therapist_client_relations_client_id_fkey (
+          id,
+          first_name,
+          last_name,
+          email,
+          created_at,
+          whatsapp_number,
+          patient_code
+        )
+      `, { count: 'exact' })
+      .eq('therapist_id', profile.id)
+      .range(pageParam * PAGE_SIZE, pageParam * PAGE_SIZE + PAGE_SIZE - 1)
+
+    if (debouncedSearch) {
+      query = query.or(
+        `profiles.first_name.ilike.%${debouncedSearch}%,profiles.last_name.ilike.%${debouncedSearch}%,profiles.email.ilike.%${debouncedSearch}%`
+      )
+    }
+
+    const { data: relations, error, count } = await query
+
+    if (error) {
+      throw error
+    }
+
+    const clientList = (relations || [])
+      .map((relation: { profiles: Client }) => relation.profiles)
+      .filter(Boolean)
+
+    let profilesMap: Record<string, ClientProfile> = {}
+    if (clientList.length > 0) {
+      const clientIds = clientList.map(c => c.id)
+      const { data: profiles } = await supabase
+        .from('client_profiles')
+        .select('client_id, risk_level, presenting_concerns, notes, intake_status, treatment_stage')
+        .in('client_id', clientIds)
+        .eq('therapist_id', profile.id)
+
+      if (profiles) {
+        profilesMap = profiles.reduce((acc, p) => {
+          acc[p.client_id] = {
+            risk_level: p.risk_level,
+            presenting_concerns: p.presenting_concerns,
+            notes: p.notes,
+            intake_status: p.intake_status,
+            treatment_stage: p.treatment_stage
+          }
+          return acc
+        }, {} as Record<string, ClientProfile>)
+      }
+    }
+
+    const totalCount = typeof count === 'number' ? count : clientList.length
+    const hasMore = (pageParam + 1) * PAGE_SIZE < totalCount
+
+    return { clients: clientList, profilesMap, hasMore, page: pageParam }
+  }
+
+  const {
+    data,
+    error,
+    isLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage
+  } = useInfiniteQuery({
+    queryKey: ['clients', profile?.id, debouncedSearch],
+    queryFn: fetchClients,
+    getNextPageParam: lastPage => (lastPage.hasMore ? lastPage.page + 1 : undefined),
+    enabled: !!profile?.id,
+    initialPageParam: 0
+  })
+
+  const clients = data?.pages.flatMap(page => page.clients) ?? []
+  const clientProfiles = Object.assign({}, ...(data?.pages.map(p => p.profilesMap) ?? [])) as Record<string, ClientProfile>
 
   useEffect(() => {
     if (!profile?.id) return
@@ -153,18 +141,17 @@ export const ClientManagement: React.FC = () => {
     const channel = supabase
       .channel('therapist-client-updates')
       .on('postgres_changes', { event: '*', schema: 'public', table: 'therapist_client_relations', filter: `therapist_id=eq.${profile.id}` }, () => {
-        fetchClients({ page: 0, search: searchTerm })
+        queryClient.invalidateQueries({ queryKey: ['clients', profile.id] })
       })
       .on('postgres_changes', { event: '*', schema: 'public', table: 'client_profiles', filter: `therapist_id=eq.${profile.id}` }, () => {
-        fetchClients({ page: 0, search: searchTerm })
+        queryClient.invalidateQueries({ queryKey: ['clients', profile.id] })
       })
       .subscribe()
 
     return () => {
       supabase.removeChannel(channel)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [profile?.id, searchTerm])
+  }, [profile?.id, queryClient])
 
   const filteredClients = clients
     .filter(client => {
@@ -244,7 +231,7 @@ export const ClientManagement: React.FC = () => {
         return
       }
 
-      await fetchClients({ page: 0, search: searchTerm })
+      await queryClient.invalidateQueries({ queryKey: ['clients', profile!.id] })
       setShowAddClient(false)
     } catch (error) {
       console.error('Error adding client:', error)
@@ -265,7 +252,7 @@ export const ClientManagement: React.FC = () => {
 
       if (error) throw error
 
-      await fetchClients({ page: 0, search: searchTerm })
+      await queryClient.invalidateQueries({ queryKey: ['clients', profile!.id] })
       setShowClientDetails(false)
     } catch (error) {
       console.error('Error updating client profile:', error)
@@ -274,11 +261,10 @@ export const ClientManagement: React.FC = () => {
   }
 
   const handleLoadMore = () => {
-    const nextPage = page + 1
-    fetchClients({ page: nextPage, search: searchTerm, append: true })
+    if (hasNextPage) fetchNextPage()
   }
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
@@ -291,7 +277,7 @@ export const ClientManagement: React.FC = () => {
       <div className="bg-red-50 border border-red-200 rounded-lg p-4">
         <div className="flex items-center space-x-2">
           <AlertTriangle className="w-5 h-5 text-red-600" />
-          <span className="text-red-800">{error}</span>
+          <span className="text-red-800">{error instanceof Error ? error.message : 'Failed to load clients'}</span>
         </div>
       </div>
     )
@@ -447,14 +433,14 @@ export const ClientManagement: React.FC = () => {
         })}
       </div>
 
-      {hasMore && (
+      {hasNextPage && (
         <div className="flex justify-center mt-6">
           <button
             onClick={handleLoadMore}
-            disabled={loadingMore}
+            disabled={isFetchingNextPage}
             className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
           >
-            {loadingMore ? 'Loading...' : 'Load more'}
+            {isFetchingNextPage ? 'Loading...' : 'Load more'}
           </button>
         </div>
       )}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,18 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App.tsx'
 import './index.css'
 import { AuthProvider } from './context/AuthContext'
 
+const queryClient = new QueryClient()
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <AuthProvider>
-      <App />
-    </AuthProvider>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </QueryClientProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- cache Supabase queries with React Query and provide QueryClient at app root
- debounce client search and use react-query's infinite queries with realtime invalidation
- lazy-load case formulation component and cache case queries

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/main.tsx src/components/therapist/ClientManagement.tsx src/components/therapist/CaseManagement.tsx`
- `npm run build:analyze`


------
https://chatgpt.com/codex/tasks/task_e_689c4a394b10832b9255985a8cf6806e